### PR TITLE
Fix compat 3.32

### DIFF
--- a/todolist@tomMoral.org/extension.js
+++ b/todolist@tomMoral.org/extension.js
@@ -1,20 +1,20 @@
 // Authors:
-// * Baptiste Saleil http://bsaleil.org/
-// * Community: https://github.com/bsaleil/todolist-gnome-shell-extension/network
-// With code from: https://github.com/vibou/vibou.gTile
+// * Thomas Moreau http://tommoral.github.io/
+// With code from: https://github.com/bsaleil/todolist-gnome-shell-extension
 //
 // Licence: GPLv2+
 const Main = imports.ui.main;
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const todo_list = Extension.imports.gui_elements.todolist_display;
 const initTranslations = Extension.imports.utils.initTranslations;
+const debug = Extension.imports.utils.debug;
 
 let todolist;   // Todolist instance
 let meta;
 
 // Init function
-function init(metadata) 
-{       
+function init(metadata)
+{
     meta = metadata;
     initTranslations("todolist");
 }
@@ -23,7 +23,7 @@ function enable()
 {
     todolist = new todo_list.TodoList(meta);
     todolist._enable();
-    Main.panel.addToStatusArea('todolist_sec', todolist);
+    Main.panel.addToStatusArea(meta.uuid, todolist);
 }
 
 function disable()

--- a/todolist@tomMoral.org/gui_elements/entry_item.js
+++ b/todolist@tomMoral.org/gui_elements/entry_item.js
@@ -19,17 +19,11 @@ const MAX_LENGTH = 75;
 
 
 // TodoList object
-function EntryItem(){
-    this.conn = null;
-    this._init();
-}
-
-EntryItem.prototype = {
-    __proto__ : PopupMenu.PopupBaseMenuItem.prototype,
-    _init: function()
+class EntryItem extends PopupMenu.PopupBaseMenuItem{
+    constructor()
     {
         // Call base constructor and set style_class_name
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
+        super();
         this.actor.add_style_class_name('task-entry');
 
         // Add a text entry in the BaseMenuItem layout
@@ -45,17 +39,17 @@ EntryItem.prototype = {
         this.connection_ENT = this.ENT.connect(
             'key-press-event', Lang.bind(this, this._on_keypress_event));
         this.actor.add_actor(this.newTask);
-    },
-    destroy: function()
+    }
+    destroy()
     {
         this.ENT.disconnect(this.connection_ENT);
         PopupMenu.PopupBaseMenuItem.prototype.destroy.call(this);
-    },
-    isEntry: function()
+    }
+    isEntry()
     {
         return true;
-    },
-    _on_keypress_event: function(entry, event)
+    }
+    _on_keypress_event(entry, event)
     {
         // If the key press is Enter or Return,
         // add the new task to the todolist

--- a/todolist@tomMoral.org/gui_elements/task_item.js
+++ b/todolist@tomMoral.org/gui_elements/task_item.js
@@ -20,16 +20,10 @@ const GTK_CLOSE_ICON = Gio.icon_new_for_string(
     Extension.path + "/icons/gtk-close.png");
 
 // TaskItem object wrapper
-function TaskItem(task){
-    this.conn = null;
-    this._init(task);
-}
+var TaskItem = class TaskItem extends PopupMenu.PopupBaseMenuItem {
 
-TaskItem.prototype = {
-    // inherit from a PopupBaseMenuItem
-    __proto__ : PopupMenu.PopupBaseMenuItem.prototype,
-    _init: function(task){
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
+    constructor(task){
+        super();
         this.task = task;
         this.connections = []
 
@@ -39,8 +33,8 @@ TaskItem.prototype = {
         this.actor.set_layout_manager(new Clutter.BoxLayout());
 
         // Add an editable lbel to the layout to display the task
-        this._label = new St.Entry({ 
-            style_class: 'task-label', 
+        this._label = new St.Entry({
+            style_class: 'task-label',
             text: this.task.name,
             can_focus: true
         });
@@ -54,7 +48,7 @@ TaskItem.prototype = {
         conn = _ct.connect('key_focus_out', Lang.bind(this, this._rename));
         this.connections.push([_ct, conn]);
 
-        // Add a delete button for each item and connect it to 
+        // Add a delete button for each item and connect it to
         this._del_btn = new St.Button({
             style_class: 'task-supr',
             label: ''
@@ -67,32 +61,33 @@ TaskItem.prototype = {
         conn = this._del_btn.connect('clicked',  Lang.bind(this, this._emit_delete));
         this.connections.push([this._del_btn, conn]);
 
-    },
-    destroy: function(){
-        for (var connection of this.connections.reverse())
+    }
+    destroy(){
+        for (var connection of this.connections.reverse()){
             connection[0].disconnect(connection[1]);
+        }
         this.connections.length = 0;
         this.actor.destroy();
-    },
-    isEntry: function(){
+    }
+    isEntry(){
         return false;
-    },
-    _emit_delete : function(){
+    }
+    _emit_delete (){
         this.emit('supr_signal', this.task);
         this.destroy();
-    },
-    _clicked : function(actor, ev){
+    }
+    _clicked (actor, ev){
         // Add rename on double click
         if (ev.get_click_count() == 2)
             debug("Double click");
-    },
-    _rename : function(){
+    }
+    _rename (){
         // Rename the task and notify the todolist so
         // it is updated.
         name = this._label.get_text();
 
         // Return if the name did not changed or is not set
-        if(name == this.task.name || name.length == 0)  
+        if(name == this.task.name || name.length == 0)
             return;
 
         debug("Rename task" + this.task.name + " to " + name);

--- a/todolist@tomMoral.org/metadata.json
+++ b/todolist@tomMoral.org/metadata.json
@@ -1,15 +1,13 @@
 {
-  "description": "Manage todo list with an applet\n\n* Add and remove task on your list in different sections.\n* Click an item to rename it.\n* Access the extension using Hot-Key (default: Ctrl+Space)\n", 
-  "name": "Section Todo List", 
+  "description": "Manage todo list with an applet\n\n* Add and remove task on your list in different sections.\n* Click an item to rename it.\n* Access the extension using Hot-Key (default: Ctrl+Space)\n",
+  "name": "Section Todo List",
   "shell-version": [
-      "3.18",
-      "3.20",
-      "3.22",
       "3.24",
       "3.26",
       "3.28",
-      "3.30"
-  ], 
-  "url": "https://github.com/tomMoral/ToDoList", 
+      "3.30",
+      "3.32"
+  ],
+  "url": "https://github.com/tomMoral/ToDoList",
   "uuid": "todolist@tomMoral.org"
 }


### PR DESCRIPTION
I tried to use the ES6 standard javascript classes and correctly registered the class in with `GObject.registerClass`. (see [here](https://wiki.gnome.org/Projects/GnomeShell/Extensions/Writing#CA-c83e05e240e18069a10803b67187e4c5a5c78bb0_42) for more details).

Hopefully, the extension should be cleaner now and the `disable` should be working fine.

closes #10 